### PR TITLE
Patch for custom domain Origin.

### DIFF
--- a/csrfguard/.gitignore
+++ b/csrfguard/.gitignore
@@ -1,1 +1,2 @@
 /bin
+/target/

--- a/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
@@ -689,6 +689,10 @@ public final class CsrfGuard {
 		return config().isPrintConfig();
 	}
 	
+	public String getDomainOrigin() {
+		return config().getDomainOrigin();
+	}
+	
 	/**
 	 * FIXME: taken from Tomcat - ApplicationFilterFactory
 	 * 

--- a/csrfguard/src/main/java/org/owasp/csrfguard/config/ConfigurationProvider.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/config/ConfigurationProvider.java
@@ -99,6 +99,8 @@ public interface ConfigurationProvider {
 	String getJavascriptSourceFile();
 
 	boolean isJavascriptDomainStrict();
+	
+	String getDomainOrigin();
 
 	String getJavascriptCacheControl();
 

--- a/csrfguard/src/main/java/org/owasp/csrfguard/config/NullConfigurationProvider.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/config/NullConfigurationProvider.java
@@ -253,4 +253,11 @@ public final class NullConfigurationProvider implements ConfigurationProvider {
 		return false;
 	}
 
+	/**
+	 * @see org.owasp.csrfguard.config.ConfigurationProvider#getDomainOrigin()
+	 */
+	@Override
+	public String getDomainOrigin() {
+		return null;
+	}
 }

--- a/csrfguard/src/main/java/org/owasp/csrfguard/config/PropertiesConfigurationProvider.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/config/PropertiesConfigurationProvider.java
@@ -28,7 +28,6 @@
  */
 package org.owasp.csrfguard.config;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
@@ -44,7 +43,6 @@ import javax.servlet.ServletConfig;
 
 import org.owasp.csrfguard.CsrfGuardServletContextListener;
 import org.owasp.csrfguard.action.IAction;
-import org.owasp.csrfguard.config.overlay.ConfigurationOverlayProvider;
 import org.owasp.csrfguard.log.ILogger;
 import org.owasp.csrfguard.servlet.JavaScriptServlet;
 import org.owasp.csrfguard.util.CsrfGuardUtils;
@@ -53,7 +51,7 @@ import org.owasp.csrfguard.util.CsrfGuardUtils;
  * ConfifgurationProvider based on a java.util.Properties object.
  *
  */
-public final class PropertiesConfigurationProvider implements ConfigurationProvider {
+public class PropertiesConfigurationProvider implements ConfigurationProvider {
 
 	private final static String ACTION_PREFIX = "org.owasp.csrfguard.action.";
 
@@ -101,6 +99,8 @@ public final class PropertiesConfigurationProvider implements ConfigurationProvi
 	
 	private Properties propertiesCache;
 	
+	private String domainOrigin;
+	
 	public PropertiesConfigurationProvider(Properties properties) {
 		try {
 			this.propertiesCache = properties;
@@ -117,7 +117,7 @@ public final class PropertiesConfigurationProvider implements ConfigurationProvi
 			tokenPerPage = Boolean.valueOf(propertyString(properties, "org.owasp.csrfguard.TokenPerPage", "false"));
 
 			this.validationWhenNoSessionExists = Boolean.valueOf(propertyString(properties, "org.owasp.csrfguard.ValidateWhenNoSessionExists", "true"));
-			
+			this.domainOrigin = propertyString(properties, "org.owasp.csrfguard.domainOrigin", null);
 			tokenPerPagePrecreate = Boolean.valueOf(propertyString(properties, "org.owasp.csrfguard.TokenPerPagePrecreate", "false"));
 			prng = SecureRandom.getInstance(propertyString(properties, "org.owasp.csrfguard.PRNG", "SHA1PRNG"), propertyString(properties, "org.owasp.csrfguard.PRNG.Provider", "SUN"));
 			newTokenLandingPage = propertyString(properties, "org.owasp.csrfguard.NewTokenLandingPage");
@@ -571,4 +571,11 @@ public final class PropertiesConfigurationProvider implements ConfigurationProvi
 		return this.javascriptInjectFormAttributes;
 	}
 
+	/**
+	 * @see org.owasp.csrfguard.config.ConfigurationProvider#getDomainOrigin()
+	 */
+	@Override
+	public String getDomainOrigin() {
+		return domainOrigin;
+	}
 }

--- a/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
@@ -240,7 +240,7 @@ public final class JavaScriptServlet extends HttpServlet {
 		code = code.replace(INJECT_INTO_ATTRIBUTES_IDENTIFIER, Boolean.toString(csrfGuard.isJavascriptInjectIntoAttributes()));
 		code = code.replace(INJECT_INTO_XHR_IDENTIFIER, String.valueOf(csrfGuard.isAjaxEnabled()));
 		code = code.replace(TOKENS_PER_PAGE_IDENTIFIER, String.valueOf(csrfGuard.isTokenPerPageEnabled()));
-		code = code.replace(DOMAIN_ORIGIN_IDENTIFIER, CsrfGuardUtils.defaultString(parseDomain(request.getRequestURL())));
+		code = code.replace(DOMAIN_ORIGIN_IDENTIFIER, csrfGuard.getDomainOrigin() == null ? CsrfGuardUtils.defaultString(parseDomain(request.getRequestURL())) : csrfGuard.getDomainOrigin());
 		code = code.replace(DOMAIN_STRICT_IDENTIFIER, Boolean.toString(csrfGuard.isJavascriptDomainStrict()));
 		code = code.replace(CONTEXT_PATH_IDENTIFIER, CsrfGuardUtils.defaultString(request.getContextPath()));
 		code = code.replace(SERVLET_PATH_IDENTIFIER, CsrfGuardUtils.defaultString(request.getContextPath() + request.getServletPath()));


### PR DESCRIPTION
If you run application server with csrf guard behind forwarding proxy, javascript sees domain name of proxy server, not backend server. To make domain origin check work in such network configuration there needs to be way to send name of proxy server to client.

Patch adds domainOrigin property which if defined can override server name sent to client.