### PR TITLE
Fix element misses happening due to form injection

### DIFF
--- a/csrfguard/src/main/resources/csrfguard.js
+++ b/csrfguard/src/main/resources/csrfguard.js
@@ -352,6 +352,9 @@
 			if(element.tagName.toLowerCase() == "form") {
 				if(injectForms) {
 					injectTokenForm(element, tokenName, tokenValue, pageTokens,injectGetForms);
+
+					/** adjust array length after addition of new element **/
+					len = all.length;
 				}
 				if (injectFormAttributes) {
 					injectTokenAttribute(element, "action", tokenName, tokenValue, pageTokens);


### PR DESCRIPTION
Fix element misses happening due to DOM element count change happening as a result of form injection.

"all" array is getting updated with the new hidden element, increasing the count of total number of DOM elements captured into "all" array. Therefore, if "len" was not updated, last set of DOM elements will be skipped from the loop. 
