### PR TITLE
Resolve issue where redirect with a fragment is invalid after appendi…

### DIFF
--- a/csrfguard/src/main/java/org/owasp/csrfguard/http/InterceptRedirectResponse.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/http/InterceptRedirectResponse.java
@@ -33,6 +33,11 @@ public class InterceptRedirectResponse extends HttpServletResponseWrapper {
 			/** update tokens **/
 			csrfGuard.updateTokens(request);
 			
+			// Separate URL fragment from path, e.g. /myPath#myFragment becomes 
+			//[0]: /myPath [1]: myFragment
+			String[] splitOnFragement = location.split("#", 2);
+			location = splitOnFragement[0];
+
 			StringBuilder sb = new StringBuilder();
 
 			if (!sanitizedLocation.startsWith("/")) {
@@ -54,6 +59,11 @@ public class InterceptRedirectResponse extends HttpServletResponseWrapper {
 			sb.append('=');
 			sb.append(csrfGuard.getTokenValue(request, locationUri));
 			
+			// Add back fragment, if one exists
+			if(splitOnFragement.length > 1) {
+				sb.append('#').append(splitOnFragement[1]);
+			}
+
 			response.sendRedirect(sb.toString());
 		} else {
 			response.sendRedirect(sanitizedLocation);


### PR DESCRIPTION
Resolve issue where redirect with a fragment is invalid after appending token

Description:
location is tokenized on '#'. If a fragment exists, it is re-added back to location. Tokenization returns at most 2 substrings. Only the first '#' found in location is the index for tokenization, e.g. /myPath#myFragment#blah becomes [0] /myPath [1] myFragment#blah. Any '#' in the URL prior to fragment should have been encoded as '%23'.
