### PR TITLE
Small bugfixes in properties and tags

### DIFF
--- a/csrfguard-test/src/main/webapp/WEB-INF/classes/Owasp.CsrfGuard.properties
+++ b/csrfguard-test/src/main/webapp/WEB-INF/classes/Owasp.CsrfGuard.properties
@@ -386,7 +386,7 @@ org.owasp.csrfguard.JavascriptServlet.injectFormAttributes = true
 # requests. As a result, the default value of this attribute is set to true. Developers 
 # that are confident their server-side state changing controllers will only respond to 
 # POST requests (i.e. discarding GET requests) are strongly encouraged to disable this property.
-org.owasp.csrfguard.JavascriptServlet.injectIntoAttributes = true 
+org.owasp.csrfguard.JavascriptServlet.injectIntoAttributes = true
 
 
 org.owasp.csrfguard.JavascriptServlet.xRequestedWith = OWASP CSRFGuard Project

--- a/csrfguard-test/src/main/webapp/tag.jsp
+++ b/csrfguard-test/src/main/webapp/tag.jsp
@@ -23,7 +23,7 @@
 <form id="formTest1" name="formTest1" action="protect.html">
 	<input type="text" name="text" value="text"/>
 	<input type="submit" name="submit" value="submit"/>
-	<input type="hidden" name="<csrf:token-name/>" value="<csrf:token-value uri="protect.html"/>"/>
+	<input type="hidden" name="<csrf:tokenname />" value="<csrf:tokenvalue uri="protect.html"/>"/>
 </form>
 <csrf:form id="formTest2" name="formTest2" action="protect.html">
 	<input type="text" name="text" value="text"/>

--- a/csrfguard/src/main/resources/csrfguard.properties
+++ b/csrfguard/src/main/resources/csrfguard.properties
@@ -386,7 +386,7 @@ org.owasp.csrfguard.JavascriptServlet.injectFormAttributes = true
 # requests. As a result, the default value of this attribute is set to true. Developers 
 # that are confident their server-side state changing controllers will only respond to 
 # POST requests (i.e. discarding GET requests) are strongly encouraged to disable this property.
-org.owasp.csrfguard.JavascriptServlet.injectIntoAttributes = true 
+org.owasp.csrfguard.JavascriptServlet.injectIntoAttributes = true
 
 
 org.owasp.csrfguard.JavascriptServlet.xRequestedWith = OWASP CSRFGuard Project


### PR DESCRIPTION
- tag.jsp was using "csrf:" tags with hyphens.
- On the properties, there was a space after the value in
  injectIntoAttributes, causing it to not be recognised correctly on initialisation. 
