### PR TITLE
Fix: only display log message saying "[...] CsrfGuard analyzing request [...] "if it is a protected object indeed

### DIFF
--- a/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
@@ -306,6 +306,11 @@ public final class CsrfGuard {
 		HttpSession session = request.getSession(true);
 		String tokenFromSession = (String) session.getAttribute(getSessionKey());
 
+		if (!valid){
+		    /** print log message - page and method are protected **/
+		    getLogger().log(String.format("CsrfGuard analyzing request %s", request.getRequestURI()));
+		}
+		
 		/** sending request to protected resource - verify token **/
 		if (tokenFromSession != null && !valid) {
 			try {

--- a/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuardFilter.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuardFilter.java
@@ -74,7 +74,6 @@ public final class CsrfGuardFilter implements Filter {
 			}
 
 			CsrfGuard csrfGuard = CsrfGuard.getInstance();
-			csrfGuard.getLogger().log(String.format("CsrfGuard analyzing request %s", httpRequest.getRequestURI()));
 
 			InterceptRedirectResponse httpResponse = new InterceptRedirectResponse((HttpServletResponse) response, httpRequest, csrfGuard);
 


### PR DESCRIPTION
Found that log was printed for all objects matched by filter criteria in web.xml regarding the object was protected or not. It is a little confusing though. 
There were made changes to avoid that situation and only display log message when the request is related to a protected object.