### PR TITLE
Fixed improperly formatted max-age Cache-Control config

### DIFF
--- a/csrfguard/src/main/resources/csrfguard.properties
+++ b/csrfguard/src/main/resources/csrfguard.properties
@@ -345,7 +345,7 @@ org.owasp.csrfguard.JavascriptServlet.domainStrict = true
 # Caching of the dynamic JavaScript file is intended to minimize traffic and improve performance. 
 # Note that the Cache-Control header is always set to "no-store" when either the "Rotate" 
 # "TokenPerPage" options is set to true in Owasp.CsrfGuard.properties.
-org.owasp.csrfguard.JavascriptServlet.cacheControl = private, maxage=28800
+org.owasp.csrfguard.JavascriptServlet.cacheControl = private, max-age=28800
 
 # Allows the developer to specify a regular expression describing the required value of the 
 # Referer header. Any attempts to access the servlet with a Referer header that does not 


### PR DESCRIPTION
This is in response to issue #52 , which fixes the header parameter format. I disagree with the other recommendation and will comment on the issue thread directly.