### PR TITLE
Remove underscore from token name

### DIFF
--- a/csrfguard-test/src/main/webapp/WEB-INF/classes/Owasp.CsrfGuard.properties
+++ b/csrfguard-test/src/main/webapp/WEB-INF/classes/Owasp.CsrfGuard.properties
@@ -271,10 +271,10 @@ org.owasp.csrfguard.action.Rotate=org.owasp.csrfguard.action.Rotate
 #
 # The token name property (org.owasp.csrfguard.TokenName) defines the name of the HTTP parameter
 # to contain the value of the OWASP CSRFGuard token for each request. The following configuration
-# snippet sets the CSRFGuard token parameter name to the value OWASP_CSRFTOKEN:
+# snippet sets the CSRFGuard token parameter name to the value OWASP-CSRFTOKEN:
 #
-# org.owasp.csrfguard.TokenName=OWASP_CSRFTOKEN
-org.owasp.csrfguard.TokenName=OWASP_CSRFTOKEN
+# org.owasp.csrfguard.TokenName=OWASP-CSRFTOKEN
+org.owasp.csrfguard.TokenName=OWASP-CSRFTOKEN
 
 # Session Key
 #

--- a/csrfguard/src/main/java/org/owasp/csrfguard/config/PropertiesConfigurationProvider.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/config/PropertiesConfigurationProvider.java
@@ -111,7 +111,7 @@ public class PropertiesConfigurationProvider implements ConfigurationProvider {
 			unprotectedMethods = new HashSet<String>();
 			/** load simple properties **/
 			logger = (ILogger) Class.forName(propertyString(properties, "org.owasp.csrfguard.Logger", "org.owasp.csrfguard.log.ConsoleLogger")).newInstance();
-			tokenName = propertyString(properties, "org.owasp.csrfguard.TokenName", "OWASP_CSRFGUARD");
+			tokenName = propertyString(properties, "org.owasp.csrfguard.TokenName", "OWASP-CSRFGUARD");
 			tokenLength = Integer.parseInt(propertyString(properties, "org.owasp.csrfguard.TokenLength", "32"));
 			rotate = Boolean.valueOf(propertyString(properties, "org.owasp.csrfguard.Rotate", "false"));
 			tokenPerPage = Boolean.valueOf(propertyString(properties, "org.owasp.csrfguard.TokenPerPage", "false"));

--- a/csrfguard/src/main/resources/csrfguard.properties
+++ b/csrfguard/src/main/resources/csrfguard.properties
@@ -271,10 +271,10 @@ org.owasp.csrfguard.action.Rotate=org.owasp.csrfguard.action.Rotate
 #
 # The token name property (org.owasp.csrfguard.TokenName) defines the name of the HTTP parameter
 # to contain the value of the OWASP CSRFGuard token for each request. The following configuration
-# snippet sets the CSRFGuard token parameter name to the value OWASP_CSRFTOKEN:
+# snippet sets the CSRFGuard token parameter name to the value OWASP-CSRFTOKEN:
 #
-# org.owasp.csrfguard.TokenName=OWASP_CSRFTOKEN
-org.owasp.csrfguard.TokenName=OWASP_CSRFTOKEN
+# org.owasp.csrfguard.TokenName=OWASP-CSRFTOKEN
+org.owasp.csrfguard.TokenName=OWASP-CSRFTOKEN
 
 # Session Key
 #


### PR DESCRIPTION
Token name is used as HTTP header field name. Header field name containing an underscore can cause HTTP proxies to drop the header.