### PR TITLE
Fixes #83 Null pointer when using NullConfigurationProvider

### DIFF
--- a/csrfguard/src/main/java/org/owasp/csrfguard/config/NullConfigurationProvider.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/config/NullConfigurationProvider.java
@@ -81,7 +81,11 @@ public final class NullConfigurationProvider implements ConfigurationProvider {
 
 	@Override
 	public SecureRandom getPrng() {
-		return null;
+		try {
+			return SecureRandom.getInstance("SHA1PRNG", "SUN");
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	@Override

--- a/csrfguard/src/main/resources/csrfguard.js
+++ b/csrfguard/src/main/resources/csrfguard.js
@@ -75,21 +75,14 @@
 	    };
 	}();
 	
-	/** string utility functions (Polyfills from Mozilla website) **/
-    if (!String.prototype.startsWith) {
-        String.prototype.startsWith = function(searchString, position) {
-            return this.substr(position || 0, searchString.length) === searchString;
-        };
-    }
+	/** string utility functions **/
+	String.prototype.startsWith = function(prefix) {
+		return this.indexOf(prefix) === 0;
+	};
 
-    if (!String.prototype.endsWith)
-        String.prototype.endsWith = function(searchStr, Position) {
-            if (!(Position < this.length))
-                Position = this.length;
-            else
-                Position |= 0; // round position
-        return this.substr(Position - searchStr.length, searchStr.length) === searchStr;
-    };
+	String.prototype.endsWith = function(suffix) {
+		return this.match(suffix+"$") == suffix;
+	};
 
 	/** hook using standards based prototype **/
 	function hijackStandard() {

--- a/csrfguard/src/main/resources/csrfguard.js
+++ b/csrfguard/src/main/resources/csrfguard.js
@@ -75,14 +75,21 @@
 	    };
 	}();
 	
-	/** string utility functions **/
-	String.prototype.startsWith = function(prefix) {
-		return this.indexOf(prefix) === 0;
-	};
+	/** string utility functions (Polyfills from Mozilla website) **/
+    if (!String.prototype.startsWith) {
+        String.prototype.startsWith = function(searchString, position) {
+            return this.substr(position || 0, searchString.length) === searchString;
+        };
+    }
 
-	String.prototype.endsWith = function(suffix) {
-		return this.match(suffix+"$") == suffix;
-	};
+    if (!String.prototype.endsWith)
+        String.prototype.endsWith = function(searchStr, Position) {
+            if (!(Position < this.length))
+                Position = this.length;
+            else
+                Position |= 0; // round position
+        return this.substr(Position - searchStr.length, searchStr.length) === searchStr;
+    };
 
 	/** hook using standards based prototype **/
 	function hijackStandard() {


### PR DESCRIPTION
Return a default SecureRandom object from getPrng() to avoid null pointers in the code when NullConfigurationProvider is used.