### PR TITLE
Fixes #83 Null pointer when using NullConfigurationProvider

### DIFF
--- a/csrfguard/src/main/java/org/owasp/csrfguard/config/NullConfigurationProvider.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/config/NullConfigurationProvider.java
@@ -81,7 +81,11 @@ public final class NullConfigurationProvider implements ConfigurationProvider {
 
 	@Override
 	public SecureRandom getPrng() {
-		return null;
+		try {
+			return SecureRandom.getInstance("SHA1PRNG", "SUN");
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Return a default SecureRandom object from getPrng() to avoid null pointers
in the code when NullConfigurationProvider is used.