### PR TITLE
Fixes #85 String prototype override issues

### DIFF
--- a/csrfguard-test/src/main/webapp/script/csrfguard.js
+++ b/csrfguard-test/src/main/webapp/script/csrfguard.js
@@ -75,14 +75,21 @@
 	    };
 	}();
 	
-	/** string utility functions **/
-	String.prototype.startsWith = function(prefix) {
-		return this.indexOf(prefix) === 0;
-	};
+     /** string utility functions (Polyfills from Mozilla website) **/
+     if (!String.prototype.startsWith) {
+         String.prototype.startsWith = function(searchString, position) {
+             return this.substr(position || 0, searchString.length) === searchString;
+         };
+     }
 
-	String.prototype.endsWith = function(suffix) {
-		return this.match(suffix+"$") == suffix;
-	};
+     if (!String.prototype.endsWith)
+         String.prototype.endsWith = function(searchStr, Position) {
+             if (!(Position < this.length))
+                 Position = this.length;
+             else
+                 Position |= 0; // round position
+         return this.substr(Position - searchStr.length, searchStr.length) === searchStr;
+     };
 
 	/** hook using standards based prototype **/
 	function hijackStandard() {

--- a/csrfguard/src/main/resources/csrfguard.js
+++ b/csrfguard/src/main/resources/csrfguard.js
@@ -75,14 +75,21 @@
 	    };
 	}();
 	
-	/** string utility functions **/
-	String.prototype.startsWith = function(prefix) {
-		return this.indexOf(prefix) === 0;
-	};
+     /** string utility functions (Polyfills from Mozilla website) **/
+     if (!String.prototype.startsWith) {
+         String.prototype.startsWith = function(searchString, position) {
+             return this.substr(position || 0, searchString.length) === searchString;
+         };
+     }
 
-	String.prototype.endsWith = function(suffix) {
-		return this.match(suffix+"$") == suffix;
-	};
+     if (!String.prototype.endsWith)
+         String.prototype.endsWith = function(searchStr, Position) {
+             if (!(Position < this.length))
+                 Position = this.length;
+             else
+                 Position |= 0; // round position
+         return this.substr(Position - searchStr.length, searchStr.length) === searchStr;
+     };
 
 	/** hook using standards based prototype **/
 	function hijackStandard() {


### PR DESCRIPTION
csrfguard.js has String prototypes for endsWith() and startsWith() that
are defined with regexes that cause issues with some data.

Replace them with recommended polyfills from MDM.