### PR TITLE
remove tailing whitespace for boolean value, which leads to parsing t…

### DIFF
--- a/csrfguard-test/src/main/webapp/WEB-INF/classes/Owasp.CsrfGuard.properties
+++ b/csrfguard-test/src/main/webapp/WEB-INF/classes/Owasp.CsrfGuard.properties
@@ -386,7 +386,7 @@ org.owasp.csrfguard.JavascriptServlet.injectFormAttributes = true
 # requests. As a result, the default value of this attribute is set to true. Developers 
 # that are confident their server-side state changing controllers will only respond to 
 # POST requests (i.e. discarding GET requests) are strongly encouraged to disable this property.
-org.owasp.csrfguard.JavascriptServlet.injectIntoAttributes = true 
+org.owasp.csrfguard.JavascriptServlet.injectIntoAttributes = true
 
 
 org.owasp.csrfguard.JavascriptServlet.xRequestedWith = OWASP CSRFGuard Project

--- a/csrfguard/src/main/resources/csrfguard.properties
+++ b/csrfguard/src/main/resources/csrfguard.properties
@@ -386,7 +386,7 @@ org.owasp.csrfguard.JavascriptServlet.injectFormAttributes = true
 # requests. As a result, the default value of this attribute is set to true. Developers 
 # that are confident their server-side state changing controllers will only respond to 
 # POST requests (i.e. discarding GET requests) are strongly encouraged to disable this property.
-org.owasp.csrfguard.JavascriptServlet.injectIntoAttributes = true 
+org.owasp.csrfguard.JavascriptServlet.injectIntoAttributes = true
 
 
 org.owasp.csrfguard.JavascriptServlet.xRequestedWith = OWASP CSRFGuard Project


### PR DESCRIPTION
…rue to false, because we don't trim the string value when parsing