### PR TITLE
Avoid impact of JDK GZIP compression issue (JDK-8189789) on CSRFGuard

### DIFF
--- a/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
@@ -480,19 +480,7 @@ public final class CsrfGuard {
 		response.setContentLength(code.length());
 
 		/** write auto posting form **/
-		OutputStream output = null;
-		PrintWriter writer = null;
-
-		try {
-			output = response.getOutputStream();
-			writer = new PrintWriter(output);
-
-			writer.write(code);
-			writer.flush();
-		} finally {
-			Writers.close(writer);
-			Streams.close(output);
-		}
+		response.getWriter().write(code);
 	}
 
 	@Override

--- a/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/servlet/JavaScriptServlet.java
@@ -172,19 +172,7 @@ public final class JavaScriptServlet extends HttpServlet {
 		response.setContentType("text/plain");
 
 		/** write dynamic javascript **/
-		OutputStream output = null;
-		PrintWriter writer = null;
-
-		try {
-			output = response.getOutputStream();
-			writer = new PrintWriter(output);
-
-			writer.write(token_pair);
-			writer.flush();
-		} finally {
-			Writers.close(writer);
-			Streams.close(output);
-		}
+		response.getWriter().write(token_pair);
 	}
 
 
@@ -199,19 +187,7 @@ public final class JavaScriptServlet extends HttpServlet {
 		response.setContentLength(pageTokensString.length());
 
 		/** write dynamic javascript **/
-		OutputStream output = null;
-		PrintWriter writer = null;
-
-		try {
-			output = response.getOutputStream();
-			writer = new PrintWriter(output);
-
-			writer.write(pageTokensString);
-			writer.flush();
-		} finally {
-			Writers.close(writer);
-			Streams.close(output);
-		}
+		response.getWriter().write(pageTokensString);
 	}
 
 	private void writeJavaScript(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -247,19 +223,7 @@ public final class JavaScriptServlet extends HttpServlet {
 		code = code.replace(X_REQUESTED_WITH_IDENTIFIER, CsrfGuardUtils.defaultString(csrfGuard.getJavascriptXrequestedWith()));
 
 		/** write dynamic javascript **/
-		OutputStream output = null;
-		PrintWriter writer = null;
-
-		try {
-			output = response.getOutputStream();
-			writer = new PrintWriter(output);
-
-			writer.write(code);
-			writer.flush();
-		} finally {
-			Writers.close(writer);
-			Streams.close(output);
-		}
+		response.getWriter().write(code);
 	}
 
 	private String parsePageTokens(Map<String, String> pageTokens) {


### PR DESCRIPTION
JDK bug [JDK-8189789](https://bugs.openjdk.java.net/browse/JDK-8189789) related to GZIP compression with latest JDK versions impact OWASP CSRFGuard. This will result in browser not being able to inflate the GZIPed csrfguard.js. Thereby resulting in all the CSRF protected pages not to function (all protected functionalities of the application will break due to this). 

This PR contains a modification that will correct this behavior and make sure CSRFGuard is not affected, without having to wait for a JDK update. 

We reproduce this condition generally with Linux with following software:
- Reproduced on Ubuntu 12.04, 16.04
- JDK version: "jdk1.8.0_152" (latest 1.8 release)
- Tomcat version: 7.0.81 

Issue is also reproduced in Tomcat version: 7.0.81 with any JDK version on macOS High Sierra 10.13.2.

**Thanks @ruwanta for suggesting this workaround!**