### PR TITLE
Add support for tokens generation on session creation

### DIFF
--- a/csrfguard-test/src/main/webapp/WEB-INF/classes/Owasp.CsrfGuard.properties
+++ b/csrfguard-test/src/main/webapp/WEB-INF/classes/Owasp.CsrfGuard.properties
@@ -133,7 +133,7 @@ org.owasp.csrfguard.ValidateWhenNoSessionExists = true
 # org.owasp.csrfguard.TokenPerPage=true
 # org.owasp.csrfguard.TokenPerPagePrecreate=false
 org.owasp.csrfguard.TokenPerPage=true
-org.owasp.csrfguard.TokenPerPagePrecreate=false
+org.owasp.csrfguard.TokenPerPagePrecreate=true
 
 # Token Rotation
 #
@@ -178,7 +178,10 @@ org.owasp.csrfguard.Ajax=true
 # All other pages will not be protected. This is useful when the CsrfGuardFilter is aggressively mapped (ex: /*),
 # but you only want to protect a few pages.
 #
-# org.owasp.csrfguard.Protect=true
+# org.owasp.csrfguard.Protect=false
+org.owasp.csrfguard.protected.Protected=/protect.html
+org.owasp.csrfguard.protected.Test=/test.html
+org.owasp.csrfguard.protected.Forward=/forward.jsp
 
 # Unprotected Pages:
 #

--- a/csrfguard-test/src/main/webapp/WEB-INF/web.xml
+++ b/csrfguard-test/src/main/webapp/WEB-INF/web.xml
@@ -22,7 +22,7 @@
 		<filter-name>CSRFGuard</filter-name>
 		<filter-class>org.owasp.csrfguard.CsrfGuardFilter</filter-class>
 	</filter>
-	
+
 	<filter-mapping>
 		<filter-name>CSRFGuard</filter-name>
 		<url-pattern>/*</url-pattern>
@@ -31,6 +31,10 @@
 	<servlet>
 		<servlet-name>JavaScriptServlet</servlet-name>
 		<servlet-class>org.owasp.csrfguard.servlet.JavaScriptServlet</servlet-class>
+		<init-param>
+			<param-name>inject-into-attributes</param-name>
+			<param-value>true</param-value>
+		</init-param>
 	</servlet>
 
 	<servlet-mapping>

--- a/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuardFilter.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuardFilter.java
@@ -1,20 +1,20 @@
 /**
  * The OWASP CSRFGuard Project, BSD License
- * Eric Sheridan (eric@infraredsecurity.com), Copyright (c) 2011 
+ * Eric Sheridan (eric@infraredsecurity.com), Copyright (c) 2011
  * All rights reserved.
- * 
+ * <p>
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
- *    1. Redistributions of source code must retain the above copyright notice,
- *       this list of conditions and the following disclaimer.
- *    2. Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *    3. Neither the name of OWASP nor the names of its contributors may be used
- *       to endorse or promote products derived from this software without specific
- *       prior written permission.
- *
+ * <p>
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of OWASP nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific
+ * prior written permission.
+ * <p>
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -29,6 +29,7 @@
 package org.owasp.csrfguard;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -41,67 +42,67 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.owasp.csrfguard.http.InterceptRedirectResponse;
+import org.owasp.csrfguard.util.SessionUtils;
 
 public final class CsrfGuardFilter implements Filter {
 
-	private FilterConfig filterConfig = null;
+    private FilterConfig filterConfig = null;
 
-	@Override
-	public void destroy() {
-		filterConfig = null;
-	}
+    @Override
+    public void destroy() {
+        filterConfig = null;
+    }
 
-	@Override
-	public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
 
-		//maybe the short circuit to disable is set
-		if (!CsrfGuard.getInstance().isEnabled()) {
-			filterChain.doFilter(request, response);
-			return;
-		}
-		
-		/** only work with HttpServletRequest objects **/
-		if (request instanceof HttpServletRequest && response instanceof HttpServletResponse) {
-			
-			HttpServletRequest httpRequest = (HttpServletRequest) request;
-			HttpSession session = httpRequest.getSession(false);
-			
-			//if there is no session and we arent validating when no session exists
-			if (session == null && !CsrfGuard.getInstance().isValidateWhenNoSessionExists()) {
-				// If there is no session, no harm can be done
-				filterChain.doFilter(httpRequest, (HttpServletResponse) response);
-				return;
-			}
+        //maybe the short circuit to disable is set
+        if (!CsrfGuard.getInstance().isEnabled()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
 
-			CsrfGuard csrfGuard = CsrfGuard.getInstance();
+        /** only work with HttpServletRequest objects **/
+        if (request instanceof HttpServletRequest && response instanceof HttpServletResponse) {
 
-			InterceptRedirectResponse httpResponse = new InterceptRedirectResponse((HttpServletResponse) response, httpRequest, csrfGuard);
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+            HttpSession session = httpRequest.getSession(false);
+
+            //if there is no session and we arent validating when no session exists
+            if (session == null && !CsrfGuard.getInstance().isValidateWhenNoSessionExists()) {
+                // If there is no session, no harm can be done
+                filterChain.doFilter(httpRequest, (HttpServletResponse) response);
+                return;
+            }
+
+            CsrfGuard csrfGuard = CsrfGuard.getInstance();
+            InterceptRedirectResponse httpResponse = new InterceptRedirectResponse((HttpServletResponse) response, httpRequest, csrfGuard);
 
 //			 if(MultipartHttpServletRequest.isMultipartRequest(httpRequest)) {
 //				 httpRequest = new MultipartHttpServletRequest(httpRequest);
 //			 }
 
-			if ((session != null && session.isNew()) && csrfGuard.isUseNewTokenLandingPage()) {
-				csrfGuard.writeLandingPage(httpRequest, httpResponse);
-			} else if (csrfGuard.isValidRequest(httpRequest, httpResponse)) {
-				filterChain.doFilter(httpRequest, httpResponse);
-			} else {
-				/** invalid request - nothing to do - actions already executed **/
-			}
+            if ((session != null && session.isNew()) && csrfGuard.isUseNewTokenLandingPage()) {
+                csrfGuard.writeLandingPage(httpRequest, httpResponse);
+            } else if (csrfGuard.isValidRequest(httpRequest, httpResponse)) {
+                filterChain.doFilter(httpRequest, httpResponse);
+            } else {
+                /** invalid request - nothing to do - actions already executed **/
+            }
 
-			/** update tokens **/
-			csrfGuard.updateTokens(httpRequest);
+            /** update tokens **/
+            csrfGuard.updateTokens(httpRequest);
 
-		} else {
-			filterConfig.getServletContext().log(String.format("[WARNING] CsrfGuard does not know how to work with requests of class %s ", request.getClass().getName()));
+        } else {
+            filterConfig.getServletContext().log(String.format("[WARNING] CsrfGuard does not know how to work with requests of class %s ", request.getClass().getName()));
 
-			filterChain.doFilter(request, response);
-		}
-	}
+            filterChain.doFilter(request, response);
+        }
+    }
 
-	@Override
-	public void init(@SuppressWarnings("hiding") FilterConfig filterConfig) throws ServletException {
-		this.filterConfig = filterConfig;
-	}
+    @Override
+    public void init(@SuppressWarnings("hiding") FilterConfig filterConfig) throws ServletException {
+        this.filterConfig = filterConfig;
+    }
 
 }

--- a/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuardHttpSessionListener.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuardHttpSessionListener.java
@@ -1,21 +1,29 @@
 package org.owasp.csrfguard;
 
+import org.owasp.csrfguard.util.SessionUtils;
+
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpSessionEvent;
 import javax.servlet.http.HttpSessionListener;
 
 public class CsrfGuardHttpSessionListener implements HttpSessionListener {
 
-	@Override
-	public void sessionCreated(HttpSessionEvent event) {
-		HttpSession session = event.getSession();
-		CsrfGuard csrfGuard = CsrfGuard.getInstance();
-		csrfGuard.updateToken(session);
-	}
+    @Override
+    public void sessionCreated(HttpSessionEvent event) {
+        HttpSession session = event.getSession();
+        CsrfGuard csrfGuard = CsrfGuard.getInstance();
+        csrfGuard.updateToken(session);
+        // Check if should generate tokens for protected resources on current session
+        if (csrfGuard.isTokenPerPageEnabled() && csrfGuard.isTokenPerPagePrecreate()
+                && !SessionUtils.tokensGenerated(session)) {
+            csrfGuard.generatePageTokensForSession(session);
+        }
 
-	@Override
-	public void sessionDestroyed(HttpSessionEvent event) {
-		/** nothing to do **/
-	}
+    }
+
+    @Override
+    public void sessionDestroyed(HttpSessionEvent event) {
+        /** nothing to do **/
+    }
 
 }

--- a/csrfguard/src/main/java/org/owasp/csrfguard/util/CsrfGuardUtils.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/util/CsrfGuardUtils.java
@@ -1406,4 +1406,14 @@ public class CsrfGuardUtils {
 	    return str == null ? "" : str;
 	  }
 
+    @SuppressWarnings("unchecked")
+    public static <T, E> T getMapKeyByValue(Map<T, E> map, E value) {
+        for (Map.Entry<T, E> entry : map.entrySet()) {
+            if (entry.getValue().equals(value)) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
+
 }

--- a/csrfguard/src/main/java/org/owasp/csrfguard/util/SessionUtils.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/util/SessionUtils.java
@@ -1,0 +1,96 @@
+package org.owasp.csrfguard.util;
+
+import org.owasp.csrfguard.CsrfGuard;
+
+import javax.servlet.http.HttpSession;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class handles with logic between session and token manipulation.
+ */
+public final class SessionUtils {
+
+    private SessionUtils() {
+    }
+
+    private static final String TOKENS_GENERATED = "org.owasp.csrfguard.TokensGenerated";
+
+    public static boolean tokensGenerated(final HttpSession session) {
+        return session.getAttribute(TOKENS_GENERATED) != null
+                && (Boolean) session.getAttribute(TOKENS_GENERATED);
+    }
+
+    public static void setTokensGenerated(final HttpSession session) {
+
+        if (session != null) {
+            session.setAttribute(TOKENS_GENERATED, true);
+        }
+
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Map<String, String> extractPageTokensFromSession(final HttpSession session) {
+
+        final Map<String, String> pageTokens = (Map<String, String>) session.getAttribute(CsrfGuard.PAGE_TOKENS_KEY);
+
+        if (pageTokens != null) {
+            return pageTokens;
+        }
+
+        return new HashMap<String, String>(CsrfGuard.getInstance().getProtectedPages().size());
+    }
+
+    public static void updatePageTokensOnSession(final HttpSession session,
+                                                 final Map<String, String> pageTokens) {
+
+        if (session != null && pageTokens != null) {
+            session.setAttribute(CsrfGuard.PAGE_TOKENS_KEY, pageTokens);
+            setTokensGenerated(session);
+        }
+
+    }
+
+    /**
+     * Invalidates the session token and the token from the resource that
+     * has experienced an access attempt with an invalid token.
+     *
+     * @param session      - current session
+     * @param sessionToken - token from session
+     * @param requestToken - token send on request (can be a invalid token or a token from another valid resource)
+     */
+    public static void invalidateTokenForResource(final HttpSession session,
+                                                  final String sessionToken,
+                                                  final String requestToken) {
+
+        final Map<String, String> pageTokens = extractPageTokensFromSession(session);
+
+        final String actualSessionToken = getSessionToken(session);
+
+        if (actualSessionToken.equals(sessionToken)) {
+            invalidateSessionToken(session);
+        }
+
+        // Invalidate request token if it's from another existing resource
+        final String existentResource = CsrfGuardUtils.getMapKeyByValue(pageTokens, requestToken);
+        if (existentResource != null) {
+            pageTokens.put(existentResource, TokenUtils.getRandomToken());
+        }
+
+        setTokensGenerated(session);
+    }
+
+    /**
+     * Overrides the current session token with a new one.
+     *
+     * @param session - current session
+     */
+    public static void invalidateSessionToken(final HttpSession session) {
+        session.setAttribute(CsrfGuard.getInstance().getSessionKey(), TokenUtils.getRandomToken());
+    }
+
+    public static String getSessionToken(final HttpSession session) {
+        return (String) session.getAttribute(CsrfGuard.getInstance().getSessionKey());
+    }
+
+}

--- a/csrfguard/src/main/java/org/owasp/csrfguard/util/TokenUtils.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/util/TokenUtils.java
@@ -1,0 +1,20 @@
+package org.owasp.csrfguard.util;
+
+import org.owasp.csrfguard.CsrfGuard;
+
+public final class TokenUtils {
+
+    private TokenUtils() {
+    }
+
+    /**
+     * Create a random token according with configuration.
+     *
+     * @return a random token
+     */
+    public static String getRandomToken() {
+        return RandomGenerator.generateRandomId(CsrfGuard.getInstance().getPrng(),
+                CsrfGuard.getInstance().getTokenLength());
+    }
+
+}


### PR DESCRIPTION
This PR add the behavior of generate all the page tokens for protected resources on session creation phase.

With the following setup:

 - Token per page enable
 - Token per page pre create enable

When a CSRF attack is detected, the session token is invalidate, when the token passed on the request is from another valid resource this token also is invalidate and a new one is generated.

This strategy is usefull when you have a large application, with menus, forms, etc, and when the page is loaded, have all tokens generated is the best option.
