### PR TITLE
Page token not verified if Protect flag is False

### DIFF
--- a/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
+++ b/csrfguard/src/main/java/org/owasp/csrfguard/CsrfGuard.java
@@ -586,10 +586,6 @@ public final class CsrfGuard {
 		HttpSession session = request.getSession(true);
 		Map<String, String> pageTokens = SessionUtils.extractPageTokensFromSession(session);
 
-		if (!getProtectedPages().contains(request.getRequestURI())) {
-			return;
-		}
-
 		String tokenFromPages = (pageTokens != null ? pageTokens.get(request.getRequestURI()) : null);
 		String tokenFromSession = (String) session.getAttribute(getSessionKey());
 		String tokenFromRequest = request.getParameter(getTokenName());


### PR DESCRIPTION
Fixes #108 

Remove unnecessary check, because it is performed by calling isProtectedPageAndMethod() at line 1 of isValidRequest(), but most importantly - it stops validation process if page is not explicitly protected, something that is not necessary if org.owasp.csrfguard.Protect is false, which is by default.