### PR TITLE
Fixed typo error

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 
 layout: col-sidebar
-title: CSFRGuard
+title: CSRFGuard
 site_side: true
 tags: csrfguard
 project: true
@@ -11,11 +11,11 @@ type: tool
 ---
 <!-- rebuild 40 -->
 
-The OWASP CSRFGuard is one of the world’s most popular free security tools and is actively maintained by a pool of international volunteers*. It can help you automatically find security vulnerabilities in your web applications while you are developing and testing your applications. Its also a great tool for experienced pentesters to use for manual security testing.
+The OWASP CSRFGuard is one of the world’s most popular free security tools and is actively maintained by a pool of international volunteers*. It can help you automatically find security vulnerabilities in your web applications while you are developing and testing your applications. It's also a great tool for experienced pentesters to use for manual security testing.
 
 Welcome to the home of the OWASP CSRFGuard Project! OWASP CSRFGuard is a library that implements a variant of the synchronizer token pattern to mitigate the risk of Cross-Site Request Forgery (CSRF) attacks. 
 
-The OWASP CSRFGuard library is integrated through the use of a JavaEE Filter and exposes various automated and manual ways to integrate per-session or pseudo-per-request tokens into HTML. When a user interacts with this HTML, CSRF prevention tokens (i.e. cryptographically random synchronizer tokens) are submitted with the corresponding HTTP request. 
+The OWASP CSRFGuard library is integrated using JavaEE Filter and exposes various automated and manual ways to integrate per-session or pseudo-per-request tokens into HTML. When a user interacts with this HTML, CSRF prevention tokens (i.e. cryptographically random synchronizer tokens) are submitted with the corresponding HTTP request. 
 
 It is the responsibility of OWASP CSRFGuard to ensure the token is present and is valid for the current HTTP request. 
 


### PR DESCRIPTION
changed `CSFRGuard` to `CSRFGuard`
`through the use of => using` suggested by outlook as Conciseness

closes #120 